### PR TITLE
Avoid printing arguments every time

### DIFF
--- a/pdfshrink.py
+++ b/pdfshrink.py
@@ -44,8 +44,6 @@ def subdir_path(inpath, subdir):
 
 
 def main():
-    print(sys.argv)
-
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
         description=__doc__,


### PR DESCRIPTION
Remove `print(sys.args)` inside of main, otherwise it prints every time!
Do it now! @FedericoStra